### PR TITLE
Invert flipped faces for polyRoundExtrude

### DIFF
--- a/polyround.scad
+++ b/polyround.scad
@@ -29,11 +29,10 @@ let(
   points[listWrap(i+1,lp)],
 ],thick=offset,mode=isCWorCCW)];
 
-// Reverse coordinate indices of a face in order to flip its normal
-function invertFace(face) = [ for(i=[len(face) - 1:-1:0]) face[i] ];
+function reverseList(list) = [ for(i=[len(list) - 1:-1:0]) list[i] ];
 
-// Apply `invertFace` to an array of faces
-function invertFaces(faces) = [ for(f=faces) invertFace(f) ];
+// Apply `reverseList` to the array of vertex indices for an array of faces
+function invertFaces(faces) = [ for(f=faces) reverseList(f) ];
 
 function makeCurvedPartOfPolyHedron(radiiPoints,r,fn,minR=0.01)=
 // this is a private function that I'm not expecting library users to use directly
@@ -158,7 +157,7 @@ let(
   topCapFace=[for(i=[0:singeLayerLength-1])radiusPointsLength-singeLayerLength+i],
   bottomCapFace=[for(i=[0:singeLayerLength-1])radiusPointsLength*2-singeLayerLength+i],
   finalPolyhedronPoints=concat(topRadiusPoints,bottomRadiusPoints),
-  finalPolyhedronFaces=concat(topRadiusFaces, invertFaces(bottomRadiusFaces), invertFaces(sideFaces), [topCapFace], [invertFace(bottomCapFace)])
+  finalPolyhedronFaces=concat(topRadiusFaces,invertFaces(bottomRadiusFaces),invertFaces(sideFaces),[topCapFace],invertFaces([bottomCapFace]))
 )
 [
   finalPolyhedronPoints,
@@ -166,7 +165,11 @@ let(
 ];
 
 module polyRoundExtrude(radiiPoints,length=5,r1=1,r2=1,fn=10,convexity=10) {
-  polyhedronPointsNFaces=extrudePolygonWithRadius(radiiPoints,length,r1,r2,fn);
+  orderedRadiiPoints = CWorCCW(radiiPoints) == 1
+    ? reverseList(radiiPoints)
+    : radiiPoints;
+
+  polyhedronPointsNFaces=extrudePolygonWithRadius(orderedRadiiPoints,length,r1,r2,fn);
   polyhedron(points=polyhedronPointsNFaces[0], faces=polyhedronPointsNFaces[1], convexity=convexity);
 }
 

--- a/polyround.scad
+++ b/polyround.scad
@@ -29,6 +29,12 @@ let(
   points[listWrap(i+1,lp)],
 ],thick=offset,mode=isCWorCCW)];
 
+// Reverse coordinate indices of a face in order to flip its normal
+function invertFace(face) = [ for(i=[len(face) - 1:-1:0]) face[i] ];
+
+// Apply `invertFace` to an array of faces
+function invertFaces(faces) = [ for(f=faces) invertFace(f) ];
+
 function makeCurvedPartOfPolyHedron(radiiPoints,r,fn,minR=0.01)=
 // this is a private function that I'm not expecting library users to use directly
 // radiiPoints= serise of x, y, r points
@@ -152,7 +158,7 @@ let(
   topCapFace=[for(i=[0:singeLayerLength-1])radiusPointsLength-singeLayerLength+i],
   bottomCapFace=[for(i=[0:singeLayerLength-1])radiusPointsLength*2-singeLayerLength+i],
   finalPolyhedronPoints=concat(topRadiusPoints,bottomRadiusPoints),
-  finalPolyhedronFaces=concat(topRadiusFaces,bottomRadiusFaces, sideFaces, [topCapFace], [bottomCapFace])
+  finalPolyhedronFaces=concat(topRadiusFaces, invertFaces(bottomRadiusFaces), invertFaces(sideFaces), [topCapFace], [invertFace(bottomCapFace)])
 )
 [
   finalPolyhedronPoints,


### PR DESCRIPTION
I've recently started playing around with this library and noticed an issue with a `difference` operation after switching one of my designs from `polygin(polyRound(...))` to `polyRoundExtrude`.

Here's the sample script to illustrate the problem:

```
use <Round-Anything/polyround.scad>

difference() {
  translate([0, 0, -2.5]) polyRoundExtrude([
    [0, 10, 5],
    [10, 0, 5],
    [0, -10, 5],
    [-10, 0, 5]
  ]);

  sphere(d=10);
}
```

In OpenSCAD I see the following

<img width="257" alt="Screen Shot 2020-10-03 at 10 45 11 PM" src="https://user-images.githubusercontent.com/1165066/95005773-31aebd00-05ca-11eb-8d4f-10bd79b988d0.png"> <img width="253" alt="Screen Shot 2020-10-03 at 10 25 33 PM" src="https://user-images.githubusercontent.com/1165066/95005655-69693500-05c9-11eb-9369-28ba936dba3c.png">

The left is _Preview_ and the right is _Thrown Together_. If I attempt to render the result I get the following in the console:

> Parsing design (AST generation)...
> Compiling design (CSG Tree generation)...
> Rendering Polygon Mesh using CGAL...
> **ERROR: CGAL error in CGAL_Nef_polyhedron3(): CGAL ERROR: assertion violation! Expr: e->incident_sface() != SFace_const_handle() File: /Users/kintel/code/OpenSCAD/libraries/install/include/CGAL/Nef_S2/SM_const_decorator.h Line: 330**
> Geometries in cache: 1229
> Geometry cache size in bytes: 29986496
> CGAL Polyhedrons in cache: 109
> CGAL cache size in bytes: 102138824
> Total rendering time: 0 hours, 0 minutes, 0 seconds
> Rendering finished.

From what I understand about `extrudePolygonWithRadius`, it uses the same operation for the top and bottom geometry, but mirrors the coordinates in the bottom geometry along the Z axis. This works for preview, but results in inverted faces because the coordinates are no longer in the correct order.

This PR introduces a couple of helper functions to reverse the order of vertices in a list of faces and applies it to the side faces, bottom faces, and bottom cap. I notice `offsetPolygonPoints` gives some consideration to clockwise vs counter-clockwise but I'm not clear on how that gets used or if it would affect the extrude functionality.

Hope this helps! I came across your library a little while back and was really impressed, thanks for all the hard work on  it :)