### PR TITLE
Correctly instanciate recursion index

### DIFF
--- a/polyround.scad
+++ b/polyround.scad
@@ -90,7 +90,7 @@ let(
 )
 [polyhedronPoints, polyhedronFaces, layerLength];
 
-function flatternRecursion(array, init=[], currentIndex)=
+function flatternRecursion(array, init=[], currentIndex=0)=
 // this is a private function, init and currentIndex are for the function's use 
 // only for when it's calling itself, which is why there is a simplified version flatternArray that just calls this one
 // array= array to flattern by one level of nesting


### PR DESCRIPTION
Caller of the flatternRecursion method does not set necessarily the index value and OpenSCAD complain that this result in adding number to undefined.

Fixes #22 