### PR TITLE
Fix beamChain right-angles

### DIFF
--- a/polyround.scad
+++ b/polyround.scad
@@ -348,12 +348,12 @@ function findPoint(ang1,refpoint1,ang2,refpoint2,r=0)=
       refpoint1.x:
       is90or270(ang2)?
       refpoint2.x:
-      0,
+      undef,
     m1=tan(ang1),
     c1=refpoint1.y-m1*refpoint1.x,
 	  m2=tan(ang2),
     c2=refpoint2.y-m2*refpoint2.x,
-    outputX=overrideX?overrideX:(c2-c1)/(m1-m2),
+    outputX=overrideX!=undef?overrideX:(c2-c1)/(m1-m2),
     outputY=is90or270(ang1)?m2*outputX+c2:m1*outputX+c1
   )
 	[outputX,outputY,r];


### PR DESCRIPTION
Fix findPoint function to handle is90or270 properly by checking for undef rather than 0

Existing behavior does not handle right-angles in beamChain correctly. 
This was fixed previously, but there may have been regression with a change of OpenSCAD treating '0' as falsy before, and not now, However, I cannot confirm this.

The code snippit below used to cause the following error:
`WARNING: cos() parameter could not be converted: argument 0: expected number, found string ("error") in file <Round-Anything/polyround.scad>, line 687`

```
use <Round-Anything/polyround.scad>;
let (
    beam_radii_points = beamChain(
        radiiPoints=[[0, 0, 0], [40, 0, 0], [40, 40, 0], [0, 40, 0]],
        offset1=0.5,
        offset2=-0.5,
        startAngle=90,
        endAngle=90,
        mode=0,
    )
) {
    polyRoundExtrude(
        radiiPoints= beam_radii_points,
        length=5,
        r1=0,
        r2=0,
        fn=20,
        convexity=30,
    );
}
```

The above code now (correctly) creates the following model:
<img width="640" height="480" alt="image" src="https://github.com/user-attachments/assets/c052e283-01eb-4308-877a-b48ff8cb670a" />



